### PR TITLE
Improve SauceLabs behavior

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,12 @@ cache:
     - node_modules
 
 env:
-  - PHANTOM=phantomjs PHANTOM_V=1.* SCRIPT="test"
-  - PHANTOM=phantomjs-prebuilt PHANTOM_V=* SCRIPT="test"
-  - PHANTOM=phantomjs-prebuilt PHANTOM_V=* SCRIPT="test:sauce"
+  global:
+    - AFTER_SCRIPT="true"
+  matrix:
+    - PHANTOM=phantomjs PHANTOM_V=1.* SCRIPT="test"
+    - PHANTOM=phantomjs-prebuilt PHANTOM_V=* SCRIPT="test"
+    - PHANTOM=phantomjs-prebuilt PHANTOM_V=* SCRIPT="test:sauce" AFTER_SCRIPT="ember sauce:disconnect"
 
 matrix:
   fast_finish: true
@@ -35,3 +38,6 @@ install:
 script:
   - npm run test:node
   - npm run $SCRIPT
+
+after_script:
+  - $AFTER_SCRIPT

--- a/addon/services/asset-loader.js
+++ b/addon/services/asset-loader.js
@@ -258,7 +258,8 @@ export default Ember.Service.extend({
             if (sheet.href === resolvedHref) {
               // Unfortunately we have no way of knowing if the load was
               // successful or not, so we always resolve.
-              return resolve();
+              setTimeout(resolve);
+              return;
             }
           }
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "ember build",
     "start": "ember server",
     "test": "ember test",
-    "test:sauce": "ember sauce:connect && ember test --config-file testem.sauce.js --test-port 7000 && ember sauce:disconnect",
+    "test:sauce": "ember sauce:connect && ember test --config-file testem.sauce.js --test-port 7000",
     "test:node": "mocha node-tests",
     "prepublish": "./bin/install-test-addons.sh"
   },


### PR DESCRIPTION
Prior to this Travis didn't correctly disconnect from SauceLabs if a test failed. Additionally, slightly delays resolving the CSS loading promise in the event of using the stylesheet polling so that native events fire first.
