### PR TITLE
Introduce preload-assets helper for testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,19 @@ var app = new EmberApp(defaults, {
 });
 ```
 
+## Pre-loading Assets During Testing
+
+For test environments it is often useful to load all of the assets in a manifest upfront. You can do this by using the
+`preloadAssets` helper, like so:
+
+```js
+// tests/test-helper.js
+import preloadAssets from 'ember-asset-loader/test-support/preload-assets';
+import manifest from 'app/asset-manifest';
+
+preloadAssets(manifest);
+```
+
 ## Installation
 
 * `git clone https://github.com/trentmwillis/ember-asset-loader`

--- a/addon-test-support/preload-assets.js
+++ b/addon-test-support/preload-assets.js
@@ -1,0 +1,23 @@
+import Ember from 'ember';
+import AssetLoader from 'ember-asset-loader/services/asset-loader';
+
+const { Test, RSVP } = Ember;
+
+/**
+ * Preloads all the bundles specified in an asset manifest
+ * to make sure all files are available for testing.
+ *
+ * Uses the Ember.Test.Promise class to make sure tests
+ * wait for the assets to load first.
+ *
+ * @return {Promise}
+ */
+export default function preloadAssets(manifest) {
+  const loader = AssetLoader.create();
+  loader.pushManifest(manifest);
+
+  const bundlePromises = Object.keys(manifest.bundles).map((bundle) => loader.loadBundle(bundle));
+  const allBundles = RSVP.all(bundlePromises);
+
+  return Test.resolve(allBundles);
+}


### PR DESCRIPTION
Needed in consuming apps/addons (reference: https://github.com/dgeb/ember-engines/pull/184).
