### PR TITLE
Avoid using Ember's internal symbol utility.

### DIFF
--- a/addon/services/asset-loader.js
+++ b/addon/services/asset-loader.js
@@ -5,10 +5,7 @@ import BundleLoadError from '../errors/bundle-load';
 import JsLoader from '../loaders/js';
 import CssLoader from '../loaders/css';
 
-// PRIVATE STUFF, YOU SHOULD NOT NORMALLY DO THIS
-const symbol = Ember.__loader.require('ember-metal/symbol').default;
-
-export const RETRY_LOAD_SECRET = symbol('RETRY_LOAD_SECRET');
+export function RETRY_LOAD_SECRET() { }
 
 /**
  * Merges two manifests' bundles together and returns a new manifest.

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
     "ember-cli-inject-live-reload": "^1.4.0",
     "ember-cli-jshint": "^1.0.0",
-    "ember-cli-qunit": "^2.1.0",
+    "ember-cli-qunit": "^3.0.0",
     "ember-cli-release": "^0.2.9",
     "ember-cli-sauce": "1.6.0",
     "ember-cli-sri": "^2.1.0",


### PR DESCRIPTION
`symbol` is intended to give a good way to build an interned string (to avoid the performance penalty of comparing strings stored as a rope). Ember changed where `symbol` was kept upstream, breaking this addon.

In our usage scenarios, the thing we want to guarantee is that it is difficult (not impossible since we export the value) to "forge" this value. Using a function serves both purposes; it is fast for comparison, and its identity cannot be forged (one `function() {} !== function() {}`).
