### PR TITLE
Move asset-manifest modules into config namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ performance for your consumers. However, lazy loading assets on your server is n
 can actually have negative performance impact. Due to that, the recommendation is to pre-load all your assets in the
 server.
 
-Additionally, at build time we will generate a `node-asset-manifest` file that should be included in your SSR
+Additionally, at build time we will generate an `assets/node-asset-manifest.js` file that should be included in your SSR
 environment to ensure that your application can correctly access asset information.
 
 See the ["How to handle running in Node"](https://github.com/trentmwillis/ember-asset-loader/issues/21) issue for more
@@ -79,7 +79,7 @@ For test environments it is often useful to load all of the assets in a manifest
 ```js
 // tests/test-helper.js
 import preloadAssets from 'ember-asset-loader/test-support/preload-assets';
-import manifest from 'app/asset-manifest';
+import manifest from 'app/config/asset-manifest';
 
 preloadAssets(manifest);
 ```

--- a/app/config/asset-manifest.js
+++ b/app/config/asset-manifest.js
@@ -1,8 +1,8 @@
-import environment from './config/environment';
+import environment from './environment';
 
 const modulePrefix = environment.modulePrefix;
-const metaName = `${modulePrefix}/asset-manifest`;
-const nodeName = `${modulePrefix}/node-asset-manifest`;
+const metaName = `${modulePrefix}/config/asset-manifest`;
+const nodeName = `${modulePrefix}/config/node-asset-manifest`;
 
 let config = {};
 

--- a/app/instance-initializers/load-asset-manifest.js
+++ b/app/instance-initializers/load-asset-manifest.js
@@ -1,4 +1,4 @@
-import manifest from '../asset-manifest';
+import manifest from '../config/asset-manifest';
 
 /**
  * Initializes the AssetLoader service with a generated asset-manifest.

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ module.exports = {
     if (app && app.options && app.options.assetLoader && app.options.assetLoader.noManifest) {
       tree = new Funnel(tree, {
         exclude: [
-          'asset-manifest.js',
+          'config/asset-manifest.js',
           'instance-initializers/load-asset-manifest.js'
         ]
       });

--- a/lib/manifest-generator.js
+++ b/lib/manifest-generator.js
@@ -21,7 +21,7 @@ var ManifestGenerator = Addon.extend({
     var app = findHost(this);
     var options = app && app.options && app.options.assetLoader;
     if (type === 'head-footer' && !(options && options.noManifest)) {
-      var metaName = config.modulePrefix + '/asset-manifest';
+      var metaName = config.modulePrefix + '/config/asset-manifest';
       return '<meta name="' + metaName + '" content="%GENERATED_ASSET_MANIFEST%" />';
     }
   },

--- a/lib/meta-handler.js
+++ b/lib/meta-handler.js
@@ -2,7 +2,7 @@
  * Replace the manifest meta tag with an updated version of the manifest.
  * We do this in both the app's and test's index.html file.
  */
-var regex = /<meta name="([^"]*\/asset-manifest)" content=[^>]*>/;
+var regex = /<meta name="([^"]*\/config\/asset-manifest)" content=[^>]*>/;
 
 function escaper(sourceJSON) {
   return escape(JSON.stringify(sourceJSON));

--- a/lib/utils/node-module-template.js
+++ b/lib/utils/node-module-template.js
@@ -1,5 +1,5 @@
 /* eslint-disable */
-define('APP_NAME/node-asset-manifest', function() {
+define('APP_NAME/config/node-asset-manifest', function() {
   return {
     default: ASSET_MANIFEST
   };

--- a/node-tests/fixtures/generator-test/extra.html
+++ b/node-tests/fixtures/generator-test/extra.html
@@ -13,7 +13,7 @@
     <link rel="stylesheet" href="/assets/vendor.css">
     <link rel="stylesheet" href="/assets/dummy.css">
 
-    <meta name="dummy/asset-manifest" content="" />
+    <meta name="dummy/config/asset-manifest" content="" />
   </head>
   <body>
 

--- a/node-tests/fixtures/generator-test/index.html
+++ b/node-tests/fixtures/generator-test/index.html
@@ -13,7 +13,7 @@
     <link rel="stylesheet" href="/assets/vendor.css">
     <link rel="stylesheet" href="/assets/dummy.css">
 
-    <meta name="dummy/asset-manifest" content="" />
+    <meta name="dummy/config/asset-manifest" content="" />
   </head>
   <body>
 

--- a/node-tests/fixtures/generator-test/tests/index.html
+++ b/node-tests/fixtures/generator-test/tests/index.html
@@ -15,7 +15,7 @@
     <link rel="stylesheet" href="/assets/dummy.css">
     <link rel="stylesheet" href="/assets/test-support.css">
 
-    <meta name="dummy/asset-manifest" content="" />
+    <meta name="dummy/config/asset-manifest" content="" />
 
   </head>
   <body>

--- a/node-tests/fixtures/insertion-test/extra.html
+++ b/node-tests/fixtures/insertion-test/extra.html
@@ -13,7 +13,7 @@
     <link rel="stylesheet" href="/assets/vendor.css">
     <link rel="stylesheet" href="/assets/dummy.css">
 
-    <meta name="dummy/asset-manifest" content="" />
+    <meta name="dummy/config/asset-manifest" content="" />
   </head>
   <body>
 

--- a/node-tests/fixtures/insertion-test/index.html
+++ b/node-tests/fixtures/insertion-test/index.html
@@ -13,7 +13,7 @@
     <link rel="stylesheet" href="/assets/vendor.css">
     <link rel="stylesheet" href="/assets/dummy.css">
 
-    <meta name="dummy/asset-manifest" content="" />
+    <meta name="dummy/config/asset-manifest" content="" />
   </head>
   <body>
 

--- a/node-tests/fixtures/insertion-test/tests/index.html
+++ b/node-tests/fixtures/insertion-test/tests/index.html
@@ -15,7 +15,7 @@
     <link rel="stylesheet" href="/assets/dummy.css">
     <link rel="stylesheet" href="/assets/test-support.css">
 
-    <meta name="dummy/asset-manifest" content="" />
+    <meta name="dummy/config/asset-manifest" content="" />
 
   </head>
   <body>

--- a/node-tests/manifest-generator-test.js
+++ b/node-tests/manifest-generator-test.js
@@ -27,7 +27,7 @@ describe('manifest-generator', function() {
     it('returns a meta tag with a placeholder for head-footer', function() {
       var generator = createGenerator();
       var result = generator.contentFor('head-footer', { modulePrefix: 'dummy' });
-      assert.equal(result, '<meta name="dummy/asset-manifest" content="%GENERATED_ASSET_MANIFEST%" />');
+      assert.equal(result, '<meta name="dummy/config/asset-manifest" content="%GENERATED_ASSET_MANIFEST%" />');
     });
 
     it('returns nothing when using the noManifest option', function() {

--- a/node-tests/meta-handler-tests.js
+++ b/node-tests/meta-handler-tests.js
@@ -2,7 +2,7 @@ var assert = require('assert');
 var metaHandler = require('../lib/meta-handler');
 
 function testStringGenerator(sourceJSON) {
-  return '<meta name="testing/asset-manifest" content="'+ metaHandler.escaper(sourceJSON) +'" />';
+  return '<meta name="testing/config/asset-manifest" content="'+ metaHandler.escaper(sourceJSON) +'" />';
 }
 
 describe('meta-handler', function() {

--- a/tests/unit/asset-manifest-test.js
+++ b/tests/unit/asset-manifest-test.js
@@ -5,25 +5,25 @@ import { module, test } from 'qunit';
 module('Unit | asset-manifest', {
   beforeEach() {
     resetModules();
-    this.originalNodeModule = require.entries['dummy/node-asset-manifest'];
+    this.originalNodeModule = require.entries['dummy/config/node-asset-manifest'];
   },
 
   afterEach() {
-    require.entries['dummy/node-asset-manifest'] = this.originalNodeModule;
+    require.entries['dummy/config/node-asset-manifest'] = this.originalNodeModule;
     resetModules();
   }
 });
 
 function resetModules() {
-  require.unsee('dummy/node-asset-manifest');
-  require.unsee('dummy/asset-manifest');
+  require.unsee('dummy/config/node-asset-manifest');
+  require.unsee('dummy/config/asset-manifest');
 }
 
 test('node-asset-manifest is generated properly', function(assert) {
-  const nodeManifest = require('dummy/node-asset-manifest').default;
-  delete require.entries['dummy/node-asset-manifest'];
+  const nodeManifest = require('dummy/config/node-asset-manifest').default;
+  delete require.entries['dummy/config/node-asset-manifest'];
 
-  const manifest = require('dummy/asset-manifest').default;
+  const manifest = require('dummy/config/asset-manifest').default;
 
   assert.notStrictEqual(nodeManifest, manifest);
   assert.deepEqual(nodeManifest, manifest);
@@ -31,27 +31,27 @@ test('node-asset-manifest is generated properly', function(assert) {
 
 test('loads the node-asset-manifest if present', function(assert) {
   const replacementModule = {};
-  define('dummy/node-asset-manifest', () => ({ default: replacementModule}));
+  define('dummy/config/node-asset-manifest', () => ({ default: replacementModule}));
 
-  assert.strictEqual(require('dummy/asset-manifest').default, replacementModule);
+  assert.strictEqual(require('dummy/config/asset-manifest').default, replacementModule);
 });
 
 test('loads the manifest from the meta tag if available', function(assert) {
-  delete require.entries['dummy/node-asset-manifest'];
+  delete require.entries['dummy/config/node-asset-manifest'];
 
-  const meta = document.querySelector('meta[name="dummy/asset-manifest"]');
+  const meta = document.querySelector('meta[name="dummy/config/asset-manifest"]');
   const metaContent = meta.getAttribute('content');
   meta.setAttribute('content', '{"derp":"herp"}');
-  assert.deepEqual(require('dummy/asset-manifest').default, { derp: 'herp' });
+  assert.deepEqual(require('dummy/config/asset-manifest').default, { derp: 'herp' });
   meta.setAttribute('content', metaContent);
 });
 
 test('throws an error if unable to load the manifest', function(assert) {
-  delete require.entries['dummy/node-asset-manifest'];
+  delete require.entries['dummy/config/node-asset-manifest'];
 
-  const meta = document.querySelector('meta[name="dummy/asset-manifest"]');
+  const meta = document.querySelector('meta[name="dummy/config/asset-manifest"]');
   const metaContent = meta.getAttribute('content');
   meta.setAttribute('content', 'herp');
-  assert.throws(() => assert.deepEqual(require('dummy/asset-manifest').default, {}));
+  assert.throws(() => assert.deepEqual(require('dummy/config/asset-manifest').default, {}));
   meta.setAttribute('content', metaContent);
 });


### PR DESCRIPTION
Aligns with the Ember-CLI convention of putting runtime meta type information into the "config" namespace.
