### PR TITLE
Add generateURI option for customizing URIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,24 @@ var app = new EmberApp(defaults, {
 });
 ```
 
+### Generating Custom URIs
+
+Custom URIs are often needed due to serving assets from CDNs or another server that does not share the same root
+location as your application. Instead of having to write a custom Broccoli plugin or other build-time transform, you can
+specify a `generateURI` function as part of your application's options:
+
+```js
+var app = new EmberApp(defaults, {
+  assetLoader: {
+    generateURI: function(filePath) {
+      return 'http://cdn.io/' + filePath;
+    }
+  }
+});
+```
+
+The function receives the `filePath` for each asset and must return a string.
+
 ## Usage with FastBoot / Server-Side Rendering Solutions
 
 Using lazily loaded assets with a server-side rendering solution, such as FastBoot, is often desirable to maximize

--- a/lib/asset-manifest-generator.js
+++ b/lib/asset-manifest-generator.js
@@ -18,6 +18,9 @@ function AssetManifestGenerator(inputTrees, options) {
 
   this.prepend = options.prepend || '';
   this.supportedTypes = options.supportedTypes || DEFAULT_SUPPORTED_TYPES;
+  this.generateURI = options.generateURI || function generateURI(filePath) {
+    return filePath;
+  };
 
   Plugin.call(this, inputTrees, {
     annotation: options.annotation
@@ -52,6 +55,7 @@ AssetManifestGenerator.prototype.constructor = AssetManifestGenerator;
  */
 AssetManifestGenerator.prototype.build = function() {
   var supportedTypes = this.supportedTypes;
+  var generateURI = this.generateURI;
   var prepend = this.prepend;
   var inputPath = this.inputPaths[0];
   var existingManifestPath = this.inputPaths[1];
@@ -98,7 +102,7 @@ AssetManifestGenerator.prototype.build = function() {
 
       if (supportedTypes.indexOf(assetType) !== -1) {
         manifest.bundles[bundleName].assets.push({
-          uri: path.join(prepend, entry),
+          uri: generateURI(path.join(prepend, entry)),
           type: assetType
         });
       }

--- a/lib/generate-asset-manifest.js
+++ b/lib/generate-asset-manifest.js
@@ -23,6 +23,7 @@ module.exports = function generateAssetManifest(tree, options) {
 
   var bundlesLocation = options.bundlesLocation || 'bundles';
   var supportedTypes = options.supportedTypes;
+  var generateURI = options.generateURI;
   var appName = options.appName;
 
   // Get all the bundles for this application
@@ -39,6 +40,7 @@ module.exports = function generateAssetManifest(tree, options) {
 
   // Generate a manifest from the bundles
   var manifest = new AssetManifestGenerator([ bundles, existingManifest ], {
+    generateURI: generateURI,
     supportedTypes: supportedTypes,
     prepend: '/' + bundlesLocation,
     annotation: 'Asset Manifest Generator'

--- a/lib/manifest-generator.js
+++ b/lib/manifest-generator.js
@@ -35,13 +35,16 @@ var ManifestGenerator = Addon.extend({
 
     var app = findHost(this);
     var options = app && app.options;
-    var assetLoaderOptions = options && options.assetLoader;
+    var assetLoaderOptions = (options && options.assetLoader) || {};
 
-    if (assetLoaderOptions && assetLoaderOptions.noManifest) {
+    if (assetLoaderOptions.noManifest) {
       return tree;
     }
 
-    var manifestOptions = objectAssign({ appName: app.name }, this.manifestOptions);
+    var manifestOptions = objectAssign({
+      appName: app.name,
+      generateURI: assetLoaderOptions.generateURI
+    }, this.manifestOptions);
 
     var generateAssetManifest = require('./generate-asset-manifest'); // eslint-disable-line global-require
     var treeWithManifest = generateAssetManifest(tree, manifestOptions);

--- a/node-tests/fixtures/generator-test/expected-manifests/basic-manifest.json
+++ b/node-tests/fixtures/generator-test/expected-manifests/basic-manifest.json
@@ -1,0 +1,75 @@
+{
+  "bundles": {
+    "blog": {
+      "assets": [
+        {
+          "type": "css",
+          "uri": "/bundles/blog/assets/engine.css"
+        },
+        {
+          "type": "js",
+          "uri": "/bundles/blog/assets/engine.js"
+        },
+        {
+          "type": "css",
+          "uri": "/bundles/blog/assets/vendor.css"
+        },
+        {
+          "type": "js",
+          "uri": "/bundles/blog/assets/vendor.js"
+        },
+        {
+          "type": "css",
+          "uri": "/bundles/blog/shared/addon.css"
+        },
+        {
+          "type": "js",
+          "uri": "/bundles/blog/shared/addon.js"
+        }
+      ],
+      "dependencies": [
+        "shared"
+      ]
+    },
+    "chat": {
+      "assets": [
+        {
+          "type": "css",
+          "uri": "/bundles/chat/assets/engine.css"
+        },
+        {
+          "type": "js",
+          "uri": "/bundles/chat/assets/engine.js"
+        },
+        {
+          "type": "css",
+          "uri": "/bundles/chat/assets/vendor.css"
+        },
+        {
+          "type": "js",
+          "uri": "/bundles/chat/assets/vendor.js"
+        }
+      ]
+    },
+    "shared": {
+      "assets": [
+        {
+          "type": "css",
+          "uri": "/bundles/shared/assets/addon.css"
+        },
+        {
+          "type": "js",
+          "uri": "/bundles/shared/assets/addon.js"
+        },
+        {
+          "type": "css",
+          "uri": "/bundles/shared/assets/vendor.css"
+        },
+        {
+          "type": "js",
+          "uri": "/bundles/shared/assets/vendor.js"
+        }
+      ]
+    }
+  }
+}

--- a/node-tests/fixtures/generator-test/expected-manifests/cdn-manifest.json
+++ b/node-tests/fixtures/generator-test/expected-manifests/cdn-manifest.json
@@ -1,0 +1,75 @@
+{
+  "bundles": {
+    "blog": {
+      "assets": [
+        {
+          "type": "css",
+          "uri": "http://cdn.io/bundles/blog/assets/engine.css"
+        },
+        {
+          "type": "js",
+          "uri": "http://cdn.io/bundles/blog/assets/engine.js"
+        },
+        {
+          "type": "css",
+          "uri": "http://cdn.io/bundles/blog/assets/vendor.css"
+        },
+        {
+          "type": "js",
+          "uri": "http://cdn.io/bundles/blog/assets/vendor.js"
+        },
+        {
+          "type": "css",
+          "uri": "http://cdn.io/bundles/blog/shared/addon.css"
+        },
+        {
+          "type": "js",
+          "uri": "http://cdn.io/bundles/blog/shared/addon.js"
+        }
+      ],
+      "dependencies": [
+        "shared"
+      ]
+    },
+    "chat": {
+      "assets": [
+        {
+          "type": "css",
+          "uri": "http://cdn.io/bundles/chat/assets/engine.css"
+        },
+        {
+          "type": "js",
+          "uri": "http://cdn.io/bundles/chat/assets/engine.js"
+        },
+        {
+          "type": "css",
+          "uri": "http://cdn.io/bundles/chat/assets/vendor.css"
+        },
+        {
+          "type": "js",
+          "uri": "http://cdn.io/bundles/chat/assets/vendor.js"
+        }
+      ]
+    },
+    "shared": {
+      "assets": [
+        {
+          "type": "css",
+          "uri": "http://cdn.io/bundles/shared/assets/addon.css"
+        },
+        {
+          "type": "js",
+          "uri": "http://cdn.io/bundles/shared/assets/addon.js"
+        },
+        {
+          "type": "css",
+          "uri": "http://cdn.io/bundles/shared/assets/vendor.css"
+        },
+        {
+          "type": "js",
+          "uri": "http://cdn.io/bundles/shared/assets/vendor.js"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This allows generating custom URIs without having to add additional build steps. It could potentially replace the `prepend` option, but I feel they are complementary at this point in time. Since `prepend` is really about "where" the entries are coming from.
