### PR TITLE
Allow manifest to be transformed based on app or test index

### DIFF
--- a/lib/asset-manifest-inserter.js
+++ b/lib/asset-manifest-inserter.js
@@ -50,17 +50,19 @@ AssetManifestInserter.prototype.build = function() {
     manifest = { bundles: {} };
   }
 
-  var transformedManifest = this.transformer(manifest);
+  var appTransformedManifest = this.transformer(manifest, 'app');
 
   if (existsSync(indexFilePath)) {
     var indexFile = fs.readFileSync(indexFilePath, { encoding: 'utf8' });
-    var index = this.replacer(indexFile, transformedManifest);
+    var index = this.replacer(indexFile, appTransformedManifest);
     fs.writeFileSync(path.join(this.outputPath, this.options.indexName), index);
   }
 
+  var testsTransformedManifest = this.transformer(manifest, 'test');
+
   if (existsSync(testIndexFilePath)) {
     var testIndexFile = fs.readFileSync(testIndexFilePath, { encoding: 'utf8' });
-    var testIndex = this.replacer(testIndexFile, transformedManifest);
+    var testIndex = this.replacer(testIndexFile, testsTransformedManifest);
     fs.mkdirSync(path.join(this.outputPath, 'tests'));
     fs.writeFileSync(path.join(this.outputPath, 'tests', 'index.html'), testIndex);
   }

--- a/node-tests/asset-manifest-inserter-tests.js
+++ b/node-tests/asset-manifest-inserter-tests.js
@@ -27,7 +27,6 @@ function build(assertion, options) {
 
 describe('asset-manifest-inserter', function() {
   describe('build', function() {
-
     it('only modifies index.html', build(function(results) {
         var output = results.directory;
         assert.deepEqual(walk(output), [ 'index.html', 'tests/', 'tests/index.html' ]);
@@ -67,11 +66,16 @@ describe('asset-manifest-inserter', function() {
         var testIndex = fs.readFileSync(testIndexFilePath, { encoding: 'utf8' });
         var assetManifest = fs.readJsonSync(manifestFilePath);
 
-        var needle = 'herp-de-derp';
+        var appNeedle = 'herp-de-derp';
+        assert.notEqual(index.indexOf(appNeedle), -1);
 
-        assert.notEqual(index.indexOf(needle), -1);
-        assert.notEqual(testIndex.indexOf(needle), -1);
-      }, { transformer: function() { return 'herp-de-derp'; } })
+        var testNeedle = 'derp-de-herp';
+        assert.notEqual(testIndex.indexOf(testNeedle), -1);
+      }, {
+        transformer: function(manifest, type) {
+          return type === 'test' ? 'derp-de-herp' : 'herp-de-derp';
+        }
+      })
     );
 
   });


### PR DESCRIPTION
It's possible that consumers will want to define a separate transformation for the asset manifest they use in their application vs the one they use in their tests. For example, in the application they might want to have a CDN version and in tests they might want raw asset urls.

cc/ @nathanhammond 