### PR TITLE
Sets async to false when loading scripts.

### DIFF
--- a/addon/loaders/js.js
+++ b/addon/loaders/js.js
@@ -18,6 +18,7 @@ export default nodeLoader(function js(uri) {
     const script = createLoadElement('script', resolve, reject);
 
     script.src = uri;
+    script.async = false;
 
     document.head.appendChild(script);
   });

--- a/tests/unit/services/asset-loader-test.js
+++ b/tests/unit/services/asset-loader-test.js
@@ -288,6 +288,18 @@ test('loadAsset() - js - does not insert additional script tag if asset is in DO
   });
 });
 
+test('loadAsset() - js - sets async false to try to guarantee execution order', function(assert) {
+  assert.expect(1);
+
+  const service = this.subject();
+  const asset = { type: 'js', uri: '/unit-test.js' };
+
+  return service.loadAsset(asset).then(() => {
+    const script = document.querySelector('script[src="/unit-test.js"]');
+    assert.equal(script.async, false);
+  });
+});
+
 test('loadAsset() - css - handles successful load', function(assert) {
   assert.expect(1);
 


### PR DESCRIPTION
This helps us guarantee the order as [specified on the RFC](https://github.com/emberjs/rfcs/pull/153/files#diff-36ac857d583c44e56b932989bf30f8daR37). If the attribute isn't specified the behavior accross browsers is inconsistent, Gecko for example won't enforce execution order. Non-supporting browsers (e.g. IE9) still execut asynchronously.

On a large project, we had about a 1 error every 10,000  loads due to execution order. It didn't happen for the first 3 months that we had lazy-loading, until we added some other parts of the app with stronger dependencies in load order. Mostly AMD modules were fine, but we had some code that dependend on vendor assets that relied on globals.

Extract from https://developer.mozilla.org/en/docs/Web/HTML/Element/script

> [1] In older browsers that don't support the async attribute, parser-inserted scripts block the parser; script-inserted scripts execute asynchronously in IE and WebKit, but synchronously in Opera and pre-4.0 Firefox. In Firefox 4.0, the async DOM property defaults to true for script-created scripts, so the default behavior matches the behavior of IE and WebKit. To request script-inserted external scripts be executed in the insertion order in browsers where the document.createElement("script").async evaluates to true (such as Firefox 4.0), set .async=false on the scripts you want to maintain order. Never call document.write() from an async script. In Gecko 1.9.2, calling document.write() has an unpredictable effect. In Gecko 2.0, calling document.write() from an async script has no effect (other than printing a warning to the error console).
> [2] Starting in Gecko 2.0 (Firefox 4 / Thunderbird 3.3 / SeaMonkey 2.1), inserting script elements that have been created by calling document.createElement("script") into the DOM no longer enforces execution in insertion order. This change lets Gecko properly abide by the HTML5 specification. To make script-inserted external scripts execute in their insertion order, set .async=false on them.