### PR TITLE
Makes sure we return the same pending promise if we try to load the same asset more than once

### DIFF
--- a/addon/loaders/js.js
+++ b/addon/loaders/js.js
@@ -1,5 +1,5 @@
 import RSVP from 'rsvp';
-import { createLoadElement, nodeLoader } from './utilities';
+import { createLoadElement, nodeLoader, singlePendingPromise } from './utilities';
 
 /**
  * Default loader function for JS assets. Loads them by inserting a script tag
@@ -10,15 +10,17 @@ import { createLoadElement, nodeLoader } from './utilities';
  * @return {Promise}
  */
 export default nodeLoader(function js(uri) {
-  return new RSVP.Promise((resolve, reject) => {
-    if (document.querySelector(`script[src="${uri}"]`)) {
-      return resolve();
-    }
+  return singlePendingPromise(uri, ()=>
+    new RSVP.Promise((resolve, reject) => {
+      if (document.querySelector(`script[src="${uri}"]`)) {
+        return resolve();
+      }
 
-    const script = createLoadElement('script', resolve, reject);
+      const script = createLoadElement('script', resolve, reject);
 
-    script.src = uri;
+      script.src = uri;
 
-    document.head.appendChild(script);
-  });
+      document.head.appendChild(script);
+    })
+  );
 });

--- a/addon/loaders/utilities.js
+++ b/addon/loaders/utilities.js
@@ -2,6 +2,33 @@ import RSVP from 'rsvp';
 
 const isBrowser = typeof window !== 'undefined' && typeof document !== 'undefined';
 
+const inFlightPromises = {};
+
+/**
+ * Ensures we only have a single pending promise for any given key
+ * If called multiple times for a given key, before the promise is resolved,
+ * it will return the same promise. Once the promise is resolved
+ * all references are removed and the `promiseGenerator` will be called gain
+ *
+ * @method createLoadElement
+ * @param {String} key
+ * @param {Function} a funciton that returns a promise
+ */
+export function singlePendingPromise(key, promiseGenerator) {
+  if (inFlightPromises[key]) {
+    // We already have a promise for that script, return it.
+    return inFlightPromises[key];
+  }
+  const promise = promiseGenerator();
+  inFlightPromises[key] = promise;
+  // When the promise is either resolved/rejected, we allow for another request
+  // NOTE: we only want to prevent inflight promises, but downloading the same
+  // asset more than once may be ok (e.g. retry). js and CSS loaders already check
+  // that if the script/link node is present before attempting to add it.
+  promise.finally(()=> inFlightPromises[key] = undefined);
+  return promise;
+}
+
 /**
  * Creates a DOM element with the specified onload and onerror handlers.
  *

--- a/tests/unit/loaders/utilities-test.js
+++ b/tests/unit/loaders/utilities-test.js
@@ -1,0 +1,24 @@
+import { singlePendingPromise } from 'ember-asset-loader/loaders/utilities';
+import { module, test } from 'qunit';
+import wait from 'ember-test-helpers/wait';
+import Ember from 'ember';
+
+module('Unit | Utility | loaders utilities');
+
+test('singlePendingPromise returns the same promise on subsequent calls until the first one is settled', function(assert) {
+  assert.expect(3);
+
+  let resolve;
+  const promise = new Ember.RSVP.Promise(r=>resolve =r);
+  let returnedPromise = singlePendingPromise('test-key', ()=>promise);
+  assert.strictEqual(promise, returnedPromise);
+
+  returnedPromise = singlePendingPromise('test-key', ()=>new Ember.RSVP.Promise(()=>{}));
+  assert.strictEqual(promise, returnedPromise);
+
+  resolve(); // Settling the promise should result in a different promise being returned
+  return wait().then(() => {
+    returnedPromise = singlePendingPromise('test-key', ()=>new Ember.RSVP.Promise(()=>{}));
+    assert.notStrictEqual(promise, returnedPromise);
+  });
+});


### PR DESCRIPTION
Makes sure we return the same pending promise if we try to load the same asset more than once

Without this change, when there is a second call to loadAsset for the same `uri` before the first one resolved, we return a resolved promise immediately. This is problematic since the consumer of loadAsset or loadBundle may think that it everything finished loading, for example, for the typical case with routes, we may decide to continue the transition. 

This is another rare occurrence, but it can happen when a user clicks on a second link before we fully load the assets.