### PR TITLE
Node 0.12 compat fixes for lib/meta-handler.js.

### DIFF
--- a/lib/meta-handler.js
+++ b/lib/meta-handler.js
@@ -21,4 +21,7 @@ function replacer(fileContents, metaContents) {
   return fileContents.replace(regex, metaString);
 }
 
-module.exports = { transformer, replacer };
+module.exports = { 
+  transformer: transformer, 
+  replacer: replacer 
+};


### PR DESCRIPTION
I accidentally tested in Node 0.12 and noticed this was blowing up.

/cc @nathanhammond 