### PR TITLE
Avoid issues when the consuming app is using babel 6.

### DIFF
--- a/app/config/asset-manifest.js
+++ b/app/config/asset-manifest.js
@@ -1,3 +1,4 @@
+import require from 'require';
 import environment from './environment';
 
 const modulePrefix = environment.modulePrefix;


### PR DESCRIPTION
Using a bare `require` under Babel 6 throws errors in certain circumstances. This adds an import so Babel can determine that the global `require` is not being used.