### PR TITLE
Prevent caching failed assets

### DIFF
--- a/addon/loaders/css.js
+++ b/addon/loaders/css.js
@@ -20,7 +20,10 @@ export default nodeLoader(function css(uri) {
     }
 
     // Try using the default onload/onerror handlers...
-    const link = createLoadElement('link', resolve, reject);
+    const link = createLoadElement('link', resolve, function() {
+      this.remove();
+      reject(...arguments);
+    });
 
     link.rel = 'stylesheet';
     link.href = uri;

--- a/addon/loaders/css.js
+++ b/addon/loaders/css.js
@@ -20,11 +20,11 @@ export default nodeLoader(function css(uri) {
     }
 
     // Try using the default onload/onerror handlers...
-    const link = createLoadElement('link', resolve, function() {
+    const link = createLoadElement('link', resolve, function(error) {
       if (this.parentNode) {
         this.parentNode.removeChild(this);
       }
-      reject(...arguments);
+      reject(error);
     });
 
     link.rel = 'stylesheet';

--- a/addon/loaders/css.js
+++ b/addon/loaders/css.js
@@ -21,7 +21,9 @@ export default nodeLoader(function css(uri) {
 
     // Try using the default onload/onerror handlers...
     const link = createLoadElement('link', resolve, function() {
-      document.head.removeChild(this);
+      if (this.parentNode) {
+        this.parentNode.removeChild(this);
+      }
       reject(...arguments);
     });
 

--- a/addon/loaders/css.js
+++ b/addon/loaders/css.js
@@ -21,7 +21,7 @@ export default nodeLoader(function css(uri) {
 
     // Try using the default onload/onerror handlers...
     const link = createLoadElement('link', resolve, function() {
-      this.remove();
+      document.head.removeChild(this);
       reject(...arguments);
     });
 

--- a/addon/loaders/js.js
+++ b/addon/loaders/js.js
@@ -16,7 +16,9 @@ export default nodeLoader(function js(uri) {
     }
 
     const script = createLoadElement('script', resolve, function() {
-      document.head.removeChild(this);
+      if (this.parentNode) {
+        this.parentNode.removeChild(this);
+      }
       reject(...arguments);
     });
 

--- a/addon/loaders/js.js
+++ b/addon/loaders/js.js
@@ -15,7 +15,10 @@ export default nodeLoader(function js(uri) {
       return resolve();
     }
 
-    const script = createLoadElement('script', resolve, reject);
+    const script = createLoadElement('script', resolve, function() {
+      this.remove();
+      reject(...arguments);
+    });
 
     script.src = uri;
     script.async = false;

--- a/addon/loaders/js.js
+++ b/addon/loaders/js.js
@@ -15,11 +15,11 @@ export default nodeLoader(function js(uri) {
       return resolve();
     }
 
-    const script = createLoadElement('script', resolve, function() {
+    const script = createLoadElement('script', resolve, function(error) {
       if (this.parentNode) {
         this.parentNode.removeChild(this);
       }
-      reject(...arguments);
+      reject(error);
     });
 
     script.src = uri;

--- a/addon/loaders/js.js
+++ b/addon/loaders/js.js
@@ -16,7 +16,7 @@ export default nodeLoader(function js(uri) {
     }
 
     const script = createLoadElement('script', resolve, function() {
-      this.remove();
+      document.head.removeChild(this);
       reject(...arguments);
     });
 

--- a/addon/services/asset-loader.js
+++ b/addon/services/asset-loader.js
@@ -41,7 +41,7 @@ export default Ember.Service.extend({
    */
   init() {
     this._super(...arguments);
-    
+
     this.__manifests = [];
     this._setupCache();
     this._initAssetLoaders();
@@ -96,6 +96,8 @@ export default Ember.Service.extend({
       const errors = rejects.map((reject) => reject.reason);
 
       if (errors.length) {
+        // Evict rejected promise.
+        this._getFromCache('bundle', name, RETRY_LOAD_SECRET);
         throw new BundleLoadError(this, name, errors);
       }
 
@@ -131,6 +133,8 @@ export default Ember.Service.extend({
     const assetWithFail = assetPromise.then(
       () => ({ uri, type }),
       (error) => {
+        // Evict rejected promise.
+        this._getFromCache('asset', cacheKey, RETRY_LOAD_SECRET);
         throw new AssetLoadError(this, { uri, type }, error);
       }
     );

--- a/addon/services/asset-loader.js
+++ b/addon/services/asset-loader.js
@@ -97,7 +97,7 @@ export default Ember.Service.extend({
 
       if (errors.length) {
         // Evict rejected promise.
-        this._getFromCache('bundle', name, RETRY_LOAD_SECRET);
+        this._getFromCache('bundle', name, true);
         throw new BundleLoadError(this, name, errors);
       }
 
@@ -134,7 +134,7 @@ export default Ember.Service.extend({
       () => ({ uri, type }),
       (error) => {
         // Evict rejected promise.
-        this._getFromCache('asset', cacheKey, RETRY_LOAD_SECRET);
+        this._getFromCache('asset', cacheKey, true);
         throw new AssetLoadError(this, { uri, type }, error);
       }
     );

--- a/tests/acceptance/asset-load-test.js
+++ b/tests/acceptance/asset-load-test.js
@@ -68,20 +68,17 @@ test('visiting a route which loads a bundle', function(assert) {
   });
 });
 
-test('visiting a route which fails to load an asset', function(assert) {
+test('visiting a route which fails to load a script removes the node from DOM', function(assert) {
   assert.expect(2);
 
   const getScript = () => document.querySelector('script[src="foo.js"]');
-  const getLink = () => document.querySelector('link[href="foo.css"]');
 
   visit('asset-error');
 
   andThen(function() {
     assert.equal(currentRouteName(), 'asset-error', 'transitioned ');
 
-    return waitFor(() => {
-      return !getScript() && !getLink();
-    })
+    return waitFor(() => !getScript())
       .catch((reason) => {
         assert.notOk(true, reason.message);
       })

--- a/tests/acceptance/asset-load-test.js
+++ b/tests/acceptance/asset-load-test.js
@@ -67,3 +67,25 @@ test('visiting a route which loads a bundle', function(assert) {
       });
   });
 });
+
+test('visiting a route which fails to load an asset', function(assert) {
+  assert.expect(2);
+
+  const getScript = () => document.querySelector('script[src="foo.js"]');
+
+  visit('asset-error');
+
+  andThen(function() {
+    assert.equal(currentRouteName(), 'asset-error', 'transitioned ');
+
+    return waitFor(() => {
+      return !getScript();
+    })
+      .catch((reason) => {
+        assert.notOk(true, reason.message);
+      })
+      .then(() => {
+        assert.ok(true, 'failed script was removed from the DOM');
+      });
+  });
+});

--- a/tests/acceptance/asset-load-test.js
+++ b/tests/acceptance/asset-load-test.js
@@ -72,6 +72,7 @@ test('visiting a route which fails to load an asset', function(assert) {
   assert.expect(2);
 
   const getScript = () => document.querySelector('script[src="foo.js"]');
+  const getLink = () => document.querySelector('link[href="foo.css"]');
 
   visit('asset-error');
 
@@ -79,13 +80,13 @@ test('visiting a route which fails to load an asset', function(assert) {
     assert.equal(currentRouteName(), 'asset-error', 'transitioned ');
 
     return waitFor(() => {
-      return !getScript();
+      return !getScript() && !getLink();
     })
       .catch((reason) => {
         assert.notOk(true, reason.message);
       })
       .then(() => {
-        assert.ok(true, 'failed script was removed from the DOM');
+        assert.ok(true, 'failed assets were removed from DOM');
       });
   });
 });

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -7,6 +7,7 @@ const Router = Ember.Router.extend({
 });
 
 Router.map(function() {
+  this.route('asset-error');
 });
 
 export default Router;

--- a/tests/dummy/app/routes/asset-error.js
+++ b/tests/dummy/app/routes/asset-error.js
@@ -5,7 +5,6 @@ export default Ember.Route.extend({
 
   beforeModel() {
     this.get('assetLoader').loadAsset({ uri: 'foo.js', type: 'js' }).catch(() => {});
-    this.get('assetLoader').loadAsset({ uri: 'foo.css', type: 'css' }).catch(() => {});
 
     return this._super(...arguments);
   }

--- a/tests/dummy/app/routes/asset-error.js
+++ b/tests/dummy/app/routes/asset-error.js
@@ -5,6 +5,7 @@ export default Ember.Route.extend({
 
   beforeModel() {
     this.get('assetLoader').loadAsset({ uri: 'foo.js', type: 'js' }).catch(() => {});
+    this.get('assetLoader').loadAsset({ uri: 'foo.css', type: 'css' }).catch(() => {});
 
     return this._super(...arguments);
   }

--- a/tests/dummy/app/routes/asset-error.js
+++ b/tests/dummy/app/routes/asset-error.js
@@ -1,0 +1,11 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  assetLoader: Ember.inject.service(),
+
+  beforeModel() {
+    this.get('assetLoader').loadAsset({ uri: 'foo.js', type: 'js' }).catch(() => {});
+
+    return this._super(...arguments);
+  }
+});

--- a/tests/unit/services/asset-loader-test.js
+++ b/tests/unit/services/asset-loader-test.js
@@ -145,7 +145,6 @@ test('loadBundle() - subsequent call after rejection returns a new promise', fun
 
   service.defineLoader('fail', () => RSVP.reject('rejected'));
 
-
   return service.loadBundle('blog').then(
     shouldNotHappen(assert),
     (error) => firstRetry = error.retryLoad()


### PR DESCRIPTION
Hi. This pull contains changes to fix [ember-engines#471](https://github.com/ember-engines/ember-engines/issues/471).

The service always stores the promise even if the asset fails loading. Removing the promise and the DOM node allows to retry the load.