### PR TITLE
Prevent full page refresh when generated manifest has not changed

### DIFF
--- a/lib/asset-manifest-inserter.js
+++ b/lib/asset-manifest-inserter.js
@@ -1,4 +1,6 @@
+/* eslint-env node */
 var BroccoliCachingWriter = require('broccoli-caching-writer');
+
 var path = require('path');
 var fs = require('fs-extra');
 var existsSync = require('exists-sync');
@@ -30,9 +32,14 @@ function AssetManifestInserter(inputNodes, options) {
   this.replacer = meta.replacer;
 
   BroccoliCachingWriter.call(this, inputNodes, {
-    annotation: options.annotation
+    annotation: options.annotation,
+    persistentOutput: true
   });
   this.options = options;
+
+  // We will hold a reference to the lastIndex and the lastTestIndex to enable noop when nothing has changed
+  this.lastIndex = null;
+  this.lastTestIndex = null;
 }
 
 AssetManifestInserter.prototype.build = function() {
@@ -55,16 +62,33 @@ AssetManifestInserter.prototype.build = function() {
   if (existsSync(indexFilePath)) {
     var indexFile = fs.readFileSync(indexFilePath, { encoding: 'utf8' });
     var index = this.replacer(indexFile, appTransformedManifest);
-    fs.writeFileSync(path.join(this.outputPath, this.options.indexName), index);
+
+    // If index and lastIndex match, make this a noop to avoid triggering full page refresh
+    if (index !== this.lastIndex) {
+      this.lastIndex = index;
+      fs.writeFileSync(path.join(this.outputPath, this.options.indexName), index);
+    }
+
   }
 
   var testsTransformedManifest = this.transformer(manifest, 'test');
+  var testDirectory = path.join(this.outputPath, 'tests');
+
 
   if (existsSync(testIndexFilePath)) {
     var testIndexFile = fs.readFileSync(testIndexFilePath, { encoding: 'utf8' });
     var testIndex = this.replacer(testIndexFile, testsTransformedManifest);
-    fs.mkdirSync(path.join(this.outputPath, 'tests'));
-    fs.writeFileSync(path.join(this.outputPath, 'tests', 'index.html'), testIndex);
+
+    // If testIndex and lastTestIndex match, make this a noop to avoid triggering full page refresh
+    if (testIndex !== this.lastTestIndex) {
+
+      if (!existsSync(testDirectory)) {
+        fs.mkdirSync(path.join(this.outputPath, 'tests'));
+      }
+
+      this.lastTestIndex = testIndex;
+      fs.writeFileSync(path.join(this.outputPath, 'tests', 'index.html'), testIndex);
+    }
   }
 };
 


### PR DESCRIPTION
Fix for https://github.com/ember-engines/ember-asset-loader/issues/49

Summary

`contentFor` hook always returns this

```html
    <meta name="reproduce-asset-loader-issue/config/asset-manifest" content="%GENERATED_ASSET_MANIFEST%" />
```

which is changed during `postprocessTree` to something like

```html
<meta name="reproduce-asset-loader-issue/config/asset-manifest" content="%7B%22bundles%22%3A%7B%7D%7D" />
```

Which meant that every time any change was made, this triggered a full page refresh as the input and output tree's never match.

Using `persistentOutput` and holding a reference to the previous result allow us to avoid writing to the output tree when nothing has changed.

