### PR TITLE
Use `document.scripts` if available, and fallback to `querySelector` …

### DIFF
--- a/addon/loaders/js.js
+++ b/addon/loaders/js.js
@@ -1,5 +1,5 @@
 import RSVP from 'rsvp';
-import { createLoadElement, nodeLoader } from './utilities';
+import { createLoadElement, nodeLoader, uriIncluded } from './utilities';
 
 /**
  * Default loader function for JS assets. Loads them by inserting a script tag
@@ -11,7 +11,7 @@ import { createLoadElement, nodeLoader } from './utilities';
  */
 export default nodeLoader(function js(uri) {
   return new RSVP.Promise((resolve, reject) => {
-    if (document.querySelector(`script[src="${uri}"]`)) {
+    if (uriIncluded(uri, document)) {
       return resolve();
     }
 

--- a/addon/loaders/utilities.js
+++ b/addon/loaders/utilities.js
@@ -37,3 +37,10 @@ export function nodeLoader(loader) {
     return () => RSVP.resolve();
   }
 }
+
+export function uriIncluded (uri, document) {
+  if (document.scripts) {
+    return Array.from(document.scripts).filter(script => script.src && script.src.includes(uri));
+  }
+  return document.querySelector(`script[src="${uri}"]`);
+}

--- a/tests/unit/services/asset-loader-test.js
+++ b/tests/unit/services/asset-loader-test.js
@@ -431,3 +431,7 @@ test('pushManifest() - throws an error when merging two manifests with the same 
   service.pushManifest(manifest);
   assert.throws(() => service.pushManifest(manifest), /The bundle "blog" already exists./);
 });
+
+test('loadAsset() - if document.scripts is available, do not call querySelector', function(assert) {
+  // Do we need to introduce a mocking library? sinon?
+});


### PR DESCRIPTION
…if not

Only way I think to test is to introduce a mock library, and if `document.scripts` is defined, make sure `querySelector` is not called.

Thoughts @stefanpenner @rwjblue @scalvert
