### PR TITLE
feat: support scoped bundle names

### DIFF
--- a/lib/asset-manifest-generator.js
+++ b/lib/asset-manifest-generator.js
@@ -74,15 +74,16 @@ AssetManifestGenerator.prototype.build = function() {
   }
 
   var manifest = walk(inputPath).reduce(function(manifest, entry) {
-    var pathParts = entry.split('/');
-    var assetName = pathParts.pop();
-    var bundleName = pathParts.shift();
+    var bundleInfo = bundleInfoFromAssetEntry(entry);
+    var bundleName = bundleInfo.bundleName;
+    var assetName = bundleInfo.assetName;
+    var assetType = bundleInfo.assetType;
 
-    // If there is no assetName, then we have a directory per the rules of
-    // walk-sync. And, if there are no pathParts left we have a root directory.
-    // https://github.com/joliss/node-walk-sync/blob/master/README.md#usage
-    var isNewBundle = !assetName && pathParts.length === 0;
-    if (isNewBundle) {
+    if (!bundleInfo.isValid) {
+      return manifest;
+    }
+
+    if (bundleInfo.isNewBundle) {
       if (manifest.bundles[bundleName]) {
         throw new Error('Attempting to add bundle "' + bundleName + '" to manifest but a bundle with that name already exists.');
       }
@@ -94,28 +95,24 @@ AssetManifestGenerator.prototype.build = function() {
 
     // If the asset is named "dependencies.manifest.json" then we should read
     // the json in and set it as "dependencies" on the corresponding bundle.
-    else if (bundleName && assetName && assetName === 'dependencies.manifest.json') {
+    else if (assetName === 'dependencies.manifest.json') {
       var dependencies = fs.readJsonSync(path.join(inputPath, entry));
       manifest.bundles[bundleName].dependencies = dependencies;
     }
 
     // If the asset is in a bundle, then attempt to add it to the manifest by
     // checking if it is a supported type.
-    else if (assetName && bundleName) {
-      var assetType = assetName.split('.').pop();
+    else if (supportedTypes.indexOf(assetType) !== -1 && !stringOrRegexMatch(filesToIgnore, entry)) {
 
-      if (supportedTypes.indexOf(assetType) !== -1 && !stringOrRegexMatch(filesToIgnore, entry)) {
+      // only add non-empty assets
+      let fullPath = path.join(inputPath, entry);
+      let contents = fs.readFileSync(fullPath, 'utf-8');
 
-        // only add non-empty assets
-        let fullPath = path.join(inputPath, entry);
-        let contents = fs.readFileSync(fullPath, 'utf-8');
-
-        if (contents.trim() !== '') {
-          manifest.bundles[bundleName].assets.push({
-            uri: generateURI(path.posix.join(prepend, entry)),
-            type: assetType
-          });
-        }
+      if (contents.trim() !== '') {
+        manifest.bundles[bundleName].assets.push({
+          uri: generateURI(path.posix.join(prepend, entry)),
+          type: assetType
+        });
       }
     }
 
@@ -141,4 +138,54 @@ function stringOrRegexMatch(matchers, value) {
   return false;
 }
 
+/**
+ * @typedef {Object} BundleInfo
+ * @property {boolean} isValid - true if we have a valid new bundle name or a bundle and asset name
+ * @property {boolean} isNewBundle - true if this entry is just a bundle name
+ * @property {string} bundleName
+ * @property {string=} assetName
+ * @property {string=} assetType - asset extension
+ *
+ * @private
+ * @param {string} entry
+ * @returns {BundleInfo}
+ */
+function bundleInfoFromAssetEntry(entry) {
+  var pathParts = entry.split('/').filter(Boolean);
+
+  var bundleName = pathParts.shift();
+  // If the bundle name starts with a "@", then we have a scoped package[1]
+  // so we want to grab the next path part to complete the bundle name.
+  // [1]:https://docs.npmjs.com/misc/scope
+  if (bundleName && bundleName[0] === '@') {
+    if (!pathParts.length) {
+      return { isValid: false };
+    }
+    bundleName = [bundleName, pathParts.shift()].join('/');
+  }
+  var assetName = pathParts.pop();
+
+  // If there is no assetName, then we have a directory per the rules of
+  // walk-sync. And, if there are no pathParts left we have a root directory.
+  // https://github.com/joliss/node-walk-sync/blob/master/README.md#usage
+  var isNewBundle = !assetName && pathParts.length === 0;
+
+  // Find the file extension and strip off the leading '.'
+  var assetType;
+  if (assetName) {
+    assetType = path.extname(assetName).replace(/^\./, '') || undefined;
+  }
+
+  return {
+    isValid: isNewBundle || Boolean(bundleName && assetType),
+    isNewBundle,
+    bundleName,
+    assetName,
+    assetType
+  };
+}
+
 module.exports = AssetManifestGenerator;
+
+// export for testing
+module.exports._bundleInfoFromAssetEntry = bundleInfoFromAssetEntry;

--- a/node-tests/asset-manifest-generator-test.js
+++ b/node-tests/asset-manifest-generator-test.js
@@ -10,6 +10,7 @@ const createBuilder = helpers.createBuilder;
 const createTempDir = helpers.createTempDir;
 
 var AssetManifestGenerator = require('../lib/asset-manifest-generator');
+var bundleInfoFromAssetEntry = AssetManifestGenerator._bundleInfoFromAssetEntry;
 
 describe('asset-manifest-generator', function() {
   let input;
@@ -91,5 +92,64 @@ describe('asset-manifest-generator', function() {
         assert.ok(reason.toString().indexOf('Attempting to add bundle "blog" to manifest but a bundle with that name already exists.') !== -1);
       })
     });
+  });
+});
+
+
+describe('bundleInfoFromAssetEntry', function() {
+  it('converts basic paths from walkSync into bundle entry objects', function() {
+    assert.deepEqual(bundleInfoFromAssetEntry('package-name/'), {
+      isValid: true,
+      isNewBundle: true,
+      bundleName: 'package-name',
+      assetName: undefined,
+      assetType: undefined
+    }, 'package-name/');
+
+    assert.deepEqual(bundleInfoFromAssetEntry('package-name/path/'), {
+      isValid: false,
+      isNewBundle: false,
+      bundleName: 'package-name',
+      assetName: 'path',
+      assetType: undefined
+    }, 'package-name/path/');
+
+    assert.deepEqual(bundleInfoFromAssetEntry('package-name/path/asset.js'), {
+      isValid: true,
+      isNewBundle: false,
+      bundleName: 'package-name',
+      assetName: 'asset.js',
+      assetType: 'js'
+    }, 'package-name/path/asset.js');
+  });
+
+  it('converts scoped paths from walkSync into bundle entry objects', function() {
+    assert.deepEqual(bundleInfoFromAssetEntry('@scope/'), {
+      isValid: false
+    }, '@scope/');
+
+    assert.deepEqual(bundleInfoFromAssetEntry('@scope/package-name/'), {
+      isValid: true,
+      isNewBundle: true,
+      bundleName: '@scope/package-name',
+      assetName: undefined,
+      assetType: undefined
+    }, '@scope/package-name/');
+
+    assert.deepEqual(bundleInfoFromAssetEntry('@scope/package-name/path/'), {
+      isValid: false,
+      isNewBundle: false,
+      bundleName: '@scope/package-name',
+      assetName: 'path',
+      assetType: undefined
+    }, '@scope/package-name/path/');
+
+    assert.deepEqual(bundleInfoFromAssetEntry('@scope/package-name/path/asset.js'), {
+      isValid: true,
+      isNewBundle: false,
+      bundleName: '@scope/package-name',
+      assetName: 'asset.js',
+      assetType: 'js'
+    }, '@scope/package-name/path/asset.js');
   });
 });

--- a/node-tests/fixtures/generator-test/bundles/@scope/pkg/assets/engine.css
+++ b/node-tests/fixtures/generator-test/bundles/@scope/pkg/assets/engine.css
@@ -1,0 +1,1 @@
+/* empty on purpose */

--- a/node-tests/fixtures/generator-test/bundles/@scope/pkg/assets/engine.js
+++ b/node-tests/fixtures/generator-test/bundles/@scope/pkg/assets/engine.js
@@ -1,0 +1,1 @@
+/* empty on purpose */

--- a/node-tests/fixtures/generator-test/bundles/@scope/pkg/assets/engine.map
+++ b/node-tests/fixtures/generator-test/bundles/@scope/pkg/assets/engine.map
@@ -1,0 +1,1 @@
+/* empty on purpose */

--- a/node-tests/fixtures/generator-test/bundles/@scope/pkg/assets/secret.txt
+++ b/node-tests/fixtures/generator-test/bundles/@scope/pkg/assets/secret.txt
@@ -1,0 +1,1 @@
+/* empty on purpose */

--- a/node-tests/fixtures/generator-test/bundles/@scope/pkg/assets/vendor.css
+++ b/node-tests/fixtures/generator-test/bundles/@scope/pkg/assets/vendor.css
@@ -1,0 +1,1 @@
+/* empty on purpose */

--- a/node-tests/fixtures/generator-test/bundles/@scope/pkg/assets/vendor.js
+++ b/node-tests/fixtures/generator-test/bundles/@scope/pkg/assets/vendor.js
@@ -1,0 +1,1 @@
+/* empty on purpose */

--- a/node-tests/fixtures/generator-test/bundles/@scope/pkg/assets/vendor.map
+++ b/node-tests/fixtures/generator-test/bundles/@scope/pkg/assets/vendor.map
@@ -1,0 +1,1 @@
+/* empty on purpose */

--- a/node-tests/fixtures/generator-test/expected-manifests/basic-manifest.json
+++ b/node-tests/fixtures/generator-test/expected-manifests/basic-manifest.json
@@ -1,5 +1,25 @@
 {
   "bundles": {
+    "@scope/pkg": {
+      "assets": [
+        {
+          "type": "css",
+          "uri": "/bundles/@scope/pkg/assets/engine.css"
+        },
+        {
+          "type": "js",
+          "uri": "/bundles/@scope/pkg/assets/engine.js"
+        },
+        {
+          "type": "css",
+          "uri": "/bundles/@scope/pkg/assets/vendor.css"
+        },
+        {
+          "type": "js",
+          "uri": "/bundles/@scope/pkg/assets/vendor.js"
+        }
+      ]
+    },
     "blog": {
       "assets": [
         {

--- a/node-tests/fixtures/generator-test/expected-manifests/cdn-manifest.json
+++ b/node-tests/fixtures/generator-test/expected-manifests/cdn-manifest.json
@@ -1,5 +1,25 @@
 {
   "bundles": {
+    "@scope/pkg": {
+      "assets": [
+        {
+          "type": "css",
+          "uri": "http://cdn.io/bundles/@scope/pkg/assets/engine.css"
+        },
+        {
+          "type": "js",
+          "uri": "http://cdn.io/bundles/@scope/pkg/assets/engine.js"
+        },
+        {
+          "type": "css",
+          "uri": "http://cdn.io/bundles/@scope/pkg/assets/vendor.css"
+        },
+        {
+          "type": "js",
+          "uri": "http://cdn.io/bundles/@scope/pkg/assets/vendor.js"
+        }
+      ]
+    },
     "blog": {
       "assets": [
         {


### PR DESCRIPTION
When using an engine in a package called "@lennyburdette/my-engine", I would like to keep the following strings consistent:

* The package name (for `ember install @lennyburdette/my-engine`).
* The addon/engine name in index.js (for `this.mount('@lennyburdette/my-engine', { path: 'my-engine' })`.
* The module prefix in config/environment (for `import Foo from '@lennyburdette/my-engine'`).

Currently, ember-asset-loader generates the asset manifest using only the scope, not the full package name. This change detects package scopes and only generates bundles with full package names.