### PR TITLE
Use fx.existsSync and drop exists-sync dependency

### DIFF
--- a/lib/asset-manifest-inserter.js
+++ b/lib/asset-manifest-inserter.js
@@ -3,7 +3,6 @@ var BroccoliCachingWriter = require('broccoli-caching-writer');
 
 var path = require('path');
 var fs = require('fs-extra');
-var existsSync = require('exists-sync');
 var meta = require('./meta-handler');
 
 /**
@@ -59,7 +58,7 @@ AssetManifestInserter.prototype.build = function() {
 
   var appTransformedManifest = this.transformer(manifest, 'app');
 
-  if (existsSync(indexFilePath)) {
+  if (fs.existsSync(indexFilePath)) {
     var indexFile = fs.readFileSync(indexFilePath, { encoding: 'utf8' });
     var index = this.replacer(indexFile, appTransformedManifest);
 
@@ -75,14 +74,14 @@ AssetManifestInserter.prototype.build = function() {
   var testDirectory = path.join(this.outputPath, 'tests');
 
 
-  if (existsSync(testIndexFilePath)) {
+  if (fs.existsSync(testIndexFilePath)) {
     var testIndexFile = fs.readFileSync(testIndexFilePath, { encoding: 'utf8' });
     var testIndex = this.replacer(testIndexFile, testsTransformedManifest);
 
     // If testIndex and lastTestIndex match, make this a noop to avoid triggering full page refresh
     if (testIndex !== this.lastTestIndex) {
 
-      if (!existsSync(testDirectory)) {
+      if (!fs.existsSync(testDirectory)) {
         fs.mkdirSync(path.join(this.outputPath, 'tests'));
       }
 

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "broccoli-funnel": "^1.0.8",
     "broccoli-merge-trees": "^2.0.0",
     "ember-cli-babel": "^6.7.2",
-    "exists-sync": "^0.0.4",
     "fs-extra": "^4.0.1",
     "object-assign": "^4.1.0",
     "walk-sync": "^0.3.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2687,7 +2687,7 @@ exists-sync@0.0.3:
   version "0.0.3"
   resolved "https://registry.npmjs.org/exists-sync/-/exists-sync-0.0.3.tgz#b910000bedbb113b378b82f5f5a7638107622dcf"
 
-exists-sync@0.0.4, exists-sync@^0.0.4:
+exists-sync@0.0.4:
   version "0.0.4"
   resolved "https://registry.npmjs.org/exists-sync/-/exists-sync-0.0.4.tgz#9744c2c428cc03b01060db454d4b12f0ef3c8879"
 


### PR DESCRIPTION
Fixes this deprecation warning
```
warning ember-engines > ember-asset-loader > exists-sync@0.0.4: Please replace with usage of fs.existsSync
```