### PR TITLE
Properly extend from Error base class

### DIFF
--- a/addon/errors/load.js
+++ b/addon/errors/load.js
@@ -1,50 +1,52 @@
-function ExtendBuiltin(klass) {
-  function ExtendableBuiltin() {
-    klass.apply(this, arguments);
-  }
-
-  ExtendableBuiltin.prototype = Object.create(klass.prototype);
-  ExtendableBuiltin.prototype.constructor = ExtendableBuiltin;
-  return ExtendableBuiltin;
-}
-
 /**
  * A simple Error type to represent an error that occured while loading a
  * resource.
  *
+ * The hack to make stack and instanceof Error work is from
+ * https://stackoverflow.com/questions/1382107/whats-a-good-way-to-extend-error-in-javascript
+ *
  * @class LoadError
  * @extends Error
  */
-export default class LoadError extends ExtendBuiltin(Error) {
-  /**
-   * Constructs a new LoadError with a supplied error message and an instance
-   * of the AssetLoader service to use when retrying a load.
-   *
-   * @param {String} message
-   * @param {AssetLoader} assetLoader
-   */
-  constructor(message, assetLoader) {
-    super(...arguments);
-    this.name = 'LoadError';
-    this.message = message;
-    this.loader = assetLoader;
-  }
 
-  /**
-   * An abstract hook to define in a sub-class that specifies how to retry
-   * loading the errored resource.
-   */
-  retryLoad() {
-    throw new Error(`You must define a behavior for 'retryLoad' in a subclass.`);
+let captureErrorForStack;
+if (new Error().stack) {
+  captureErrorForStack = () => new Error();
+} else {
+  captureErrorForStack = () => {
+    try { __undef__(); } catch (e) { return e; } // eslint-disable-line
   }
+}
 
-  /**
-   * Invokes a specified method on the AssetLoader service and caches the
-   * result. Should be used in implementations of the retryLoad hook.
-   *
-   * @protected
-   */
-  _invokeAndCache(method, ...args) {
-    return this._retry || (this._retry = this.loader[method](...args));
-  }
+/**
+ * Constructs a new LoadError with a supplied error message and an instance
+ * of the AssetLoader service to use when retrying a load.
+ *
+ * @param {String} message
+ * @param {AssetLoader} assetLoader
+ */
+export default function LoadError(message, assetLoader) {
+  this.name = 'LoadError';
+  this.message = message;
+  this.loader = assetLoader;
+  this.stack = captureErrorForStack().stack;
+}
+LoadError.prototype = new Error;
+
+/**
+ * An abstract hook to define in a sub-class that specifies how to retry
+ * loading the errored resource.
+ */
+LoadError.prototype.retryLoad = function() {
+  throw new Error(`You must define a behavior for 'retryLoad' in a subclass.`);
+}
+
+/**
+ * Invokes a specified method on the AssetLoader service and caches the
+ * result. Should be used in implementations of the retryLoad hook.
+ *
+ * @protected
+ */
+LoadError.prototype._invokeAndCache = function(method, ...args) {
+  return this._retry || (this._retry = this.loader[method](...args));
 }

--- a/testem.sauce.js
+++ b/testem.sauce.js
@@ -76,24 +76,6 @@ module.exports = {
         "--u"
       ],
       "protocol": "browser"
-    },
-    "SL_IE9": {
-      "exe": "ember",
-      "args": [
-        "sauce:launch",
-        "-b",
-        "internet explorer",
-        "-v",
-        "9",
-        "--vi",
-        "public",
-        "-p",
-        "Windows 7",
-        "--at",
-        "--no-ct",
-        "--u"
-      ],
-      "protocol": "browser"
     }
   },
   "launch_in_ci": [
@@ -101,6 +83,5 @@ module.exports = {
     "SL_EDGE",
     "SL_IE11",
     "SL_IE10",
-    "SL_IE9"
   ]
 };

--- a/tests/unit/errors/asset-load-test.js
+++ b/tests/unit/errors/asset-load-test.js
@@ -16,6 +16,8 @@ module('Unit | Error | asset-load', {
 
 test('constructor() - accepts an asset and the original error', function(assert) {
   const error = new AssetLoadError(this.loader, this.asset, this.originalError);
+  assert.ok(error instanceof Error, 'AssetLoadError inherits Error');
+  assert.ok(error.stack, 'stack is preserved');
   assert.strictEqual(error.asset, this.asset, 'asset is set');
 });
 

--- a/tests/unit/errors/bundle-load-test.js
+++ b/tests/unit/errors/bundle-load-test.js
@@ -15,6 +15,8 @@ module('Unit | Error | bundle-load', {
 
 test('constructor() - accepts a bundleName and errors array', function(assert) {
   const error = new BundleLoadError(this.loader, this.bundleName, this.errors);
+  assert.ok(error instanceof Error, 'BundleLoadError inherits Error');
+  assert.ok(error.stack, 'stack is preserved');
   assert.equal(error.bundleName, this.bundleName, 'bundleName is set');
   assert.strictEqual(error.errors, this.errors, 'errors is set');
 });

--- a/tests/unit/errors/load-test.js
+++ b/tests/unit/errors/load-test.js
@@ -8,6 +8,8 @@ test('constructor() - accepts a message and a loader', function(assert) {
   const loader = {};
   const error = new LoadError(message, loader);
 
+  assert.ok(error instanceof Error, 'LoadError inherits Error');
+  assert.ok(error.stack, 'stack is preserved');
   assert.equal(error.message, message, 'message is set');
   assert.strictEqual(error.loader, loader, 'loader is set');
 });


### PR DESCRIPTION
Also add test to ensure `instanceof` and `stack`.

The `instanceof` test passed without the PR, but `stack` is missing on current HEAD.