### PR TITLE
Add optional to configure additional files to ignore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ branches:
 before_install:
   - true && `base64 --decode <<< ZXhwb3J0IFNBVUNFX1VTRVJOQU1FPXRyZW50bXdpbGxpcwo=`
   - true && `base64 --decode <<< ZXhwb3J0IFNBVUNFX0FDQ0VTU19LRVk9MjExZDUxOTAtNWQxYS00YzYzLWFhOGYtMjA1YmIzYzRlMGZmCg==`
-  - curl -o- -L https://yarnpkg.com/install.sh | bash
+  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version "1.12.1"
   - export PATH=$HOME/.yarn/bin:$PATH
 
 install:

--- a/README.md
+++ b/README.md
@@ -77,6 +77,20 @@ var app = new EmberApp(defaults, {
 
 The function receives the `filePath` for each asset and must return a string.
 
+### Ignore Files
+
+To ignore specific files during the manifest generation, use `filesToIgnore`.
+Both string and regex patterns are accepted.
+
+
+```js
+var app = new EmberApp(defaults, {
+  assetLoader: {
+    filesToIgnore: [/foo-engine/**/engine-vendor.js$/, 'vendor.js']
+  }
+});
+```
+
 ### Using With `broccoli-asset-rev`
 
 You need to make sure that `broccoli-asset-rev` runs after your ManifestGenerator addon runs. Here is an example of how to do that:

--- a/lib/manifest-generator.js
+++ b/lib/manifest-generator.js
@@ -38,10 +38,11 @@ var ManifestGenerator = Addon.extend({
       return tree;
     }
 
+    var filesToIgnore = (this.manifestOptions && this.manifestOptions.filesToIgnore || []).concat(assetLoaderOptions.filesToIgnore || []);
+
     var manifestOptions = objectAssign({
-      appName: app.name,
-      generateURI: assetLoaderOptions.generateURI
-    }, this.manifestOptions);
+      appName: app.name
+    }, this.manifestOptions, assetLoaderOptions, { filesToIgnore });
 
     var generateAssetManifest = require('./generate-asset-manifest'); // eslint-disable-line global-require
     var treeWithManifest = generateAssetManifest(tree, manifestOptions);

--- a/node-tests/manifest-generator-test.js
+++ b/node-tests/manifest-generator-test.js
@@ -137,6 +137,21 @@ describe('manifest-generator', function() {
       return verifyInsertedManifest('cdn-manifest.json', 'index.html', function(filePath) {
         return 'http://cdn.io' + filePath;
       });
-    })
+    });
+
+    it('uses filesToIgnore', co.wrap(function* () {
+      const generator = createGenerator({
+        filesToIgnore: [/chat/]
+      });
+
+      var inputTree = path.join(__dirname, 'fixtures', 'generator-test');
+      var processedTree = generator.postprocessTree('all', inputTree);
+      output = createBuilder(processedTree);
+
+      yield output.build();
+      var manifest = fs.readJsonSync(output.path('asset-manifest.json'));
+
+      assert.deepEqual(manifest.bundles.chat.assets, []);
+    }));
   });
 })


### PR DESCRIPTION
We have a use case where we need to ignore certain files within
`asset-manifest`. Instead of hacking it in `postprocessTree`, believe it's
better if we expose this functionality.

Thought about whether we should consume `assetLoaderOptions` for additional flexibility in the future... Didn't see much harm, but _very_ open to suggestions 