### PR TITLE
Fix various JSDoc issues

### DIFF
--- a/addon-test-support/loaded-asset-state.js
+++ b/addon-test-support/loaded-asset-state.js
@@ -6,7 +6,7 @@ let cachedLinkTags;
  * Determines whether an array contains the provided item.
  *
  * @param {Array} array
- * @param {Any} item
+ * @param {*} item
  * @return {Boolean}
  */
 function has(array, item) {

--- a/addon/errors/bundle-load.js
+++ b/addon/errors/bundle-load.js
@@ -14,8 +14,8 @@ export default class BundleLoadError extends LoadError {
    * the name of the bundle that was attempting to load.
    *
    * @param {AssetLoader} assetLoader
-   * @param {Asset} asset
-   * @param {Error} error
+   * @param {String} bundleName
+   * @param {Error[]} errors
    */
   constructor(assetLoader, bundleName, errors) {
     super(`The bundle "${bundleName}" failed to load.`, assetLoader);

--- a/addon/services/asset-loader.js
+++ b/addon/services/asset-loader.js
@@ -148,7 +148,7 @@ export default Ember.Service.extend({
    *
    * @public
    * @param {String} type
-   * @param {Funciton} loader
+   * @param {Function} loader
    * @return {Void}
    */
   defineLoader(type, loader) {
@@ -190,7 +190,7 @@ export default Ember.Service.extend({
    * @param {String} type
    * @param {String} key
    * @param {Boolean} evict
-   * @return {Any}
+   * @return {*}
    */
   _getFromCache(type, key, evict) {
     if (evict) {
@@ -207,8 +207,8 @@ export default Ember.Service.extend({
    * @private
    * @param {String} type
    * @param {String} key
-   * @param {Any} value
-   * @return {Any}
+   * @param {*} value
+   * @return {*}
    */
   _setInCache(type, key, value) {
     return (this.__cache[type][key] = value);


### PR DESCRIPTION
I threw this addon into VSCode and fixed various JSDoc issues that popped up (e.g. using `Any` instead of `*`). One file (`bundle-load.js`) didn't have the right parameters documented.