### PR TITLE
Add support code for future ember-auto-import versions to be used within lazy Ember Engines

### DIFF
--- a/addon/services/asset-loader.js
+++ b/addon/services/asset-loader.js
@@ -91,8 +91,8 @@ export default Ember.Service.extend({
 
     // ember-auto-import creates window.__eaiEngineLookup when a lazy engine uses eai v2.
     // this enables lazy engine's imports to be lazy themselves.
-    if (window.__eaiEngineLookup && window.__eaiEngineLookup[name]) {
-      assetPromises.push(window.__eaiEngineLookup[name]());
+    if (typeof __eaiEngineLookup === 'object' && __eaiEngineLookup[name]) {
+      assetPromises.push(__eaiEngineLookup[name]());
     }
 
     const bundlePromise = RSVP.allSettled([ ...dependencyPromises, ...assetPromises ]);

--- a/addon/services/asset-loader.js
+++ b/addon/services/asset-loader.js
@@ -89,6 +89,12 @@ export default Ember.Service.extend({
     const assets = bundle.assets || [];
     const assetPromises = assets.map((asset) => this.loadAsset(asset, retryLoad));
 
+    // ember-auto-import creates window.__eaiEngineLookup when a lazy engine uses eai v2.
+    // this enables lazy engine's imports to be lazy themselves.
+    if (window.__eaiEngineLookup && window.__eaiEngineLookup[name]) {
+      assetPromises.push(window.__eaiEngineLookup[name]());
+    }
+
     const bundlePromise = RSVP.allSettled([ ...dependencyPromises, ...assetPromises ]);
 
     const bundleWithFail = bundlePromise.then((promises) => {


### PR DESCRIPTION
Ember auto import will create this object for lazy engines such that asset loader can "lazy" load imports.

RE: https://github.com/ef4/ember-auto-import/pull/512